### PR TITLE
Improve message when blocked by CORS

### DIFF
--- a/src/exec/codapi.js
+++ b/src/exec/codapi.js
@@ -2,7 +2,8 @@
 
 const defaultUrl = "https://api.codapi.org/v1";
 const defaultErrMsg = "Something is wrong with Codapi.";
-const networkErrMsg = "Either Codapi is down or there is a network problem.";
+const networkErrMsg = `Either the origin (${document.location.origin}) doesn't have access, Codapi is down or there is a network problem.`;
+
 
 const errors = {
     400: "Bad request. Something is wrong with the request, not sure what.",


### PR DESCRIPTION
CORS errors result in an exception being thrown from the fetch call and this looks the same as something like a DNS lookup failure so we hint in the error message that one of the reasons for the failure could be that the origin isn't allowed access.

Including the current origin in the error makes it clearer for those who don't fully understand CORS.

fixes #4