### PR TITLE
Remove dependency on KeyboardEvent.keyCode

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -91,7 +91,7 @@ class CodeElement extends EventTarget {
             return;
         }
         if (event.key !== "Enter" && event.key !== "NumpadEnter") {
-          return;
+            return;
         }
         event.preventDefault();
         this.executeFunc();

--- a/src/editor.js
+++ b/src/editor.js
@@ -90,9 +90,8 @@ class CodeElement extends EventTarget {
         if (!event.ctrlKey && !event.metaKey) {
             return;
         }
-        // 10 and 13 are Enter codes
-        if (event.keyCode != 10 && event.keyCode != 13) {
-            return;
+        if (event.key !== "Enter" && event.key !== "NumpadEnter") {
+          return;
         }
         event.preventDefault();
         this.executeFunc();


### PR DESCRIPTION
The keyCode property is deprecated and has been replaced by the more human-readable code property, so this change replaces usage of keyCode with code.

See: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode