### PR TITLE
fix: handle sandbox attribute being null

### DIFF
--- a/src/executor.js
+++ b/src/executor.js
@@ -11,7 +11,7 @@ const defaultCommand = "run";
 // Executor runs the code and shows the results.
 class Executor {
     constructor({ engine, sandbox, command, template, files }) {
-        const [sandboxName, version] = text.cut(sandbox, ":");
+        const [sandboxName, version] = text.cut(sandbox || "", ":");
         this.engineName = engine || defaultEngine;
         this.sandbox = sandboxName;
         this.version = version;


### PR DESCRIPTION
When the `sandbox` attribute was null I got an exception in the executor constructor.

My use case is using codeapi in React, which sets the attributes one by one, which each triggers `CodapiSnippet.attributeChangedCallback`.

I suspect this fixes https://github.com/nalgeon/codapi-js/issues/26